### PR TITLE
Do not rely on implicitly created globals

### DIFF
--- a/src/data.table.jl
+++ b/src/data.table.jl
@@ -8,6 +8,7 @@ DataFrames.ncol(x::AbstractArray) = size(x, 2)
 
 ## module: data ================================================================
 module data
+global table, frame
 end
 data.table = DataFrame
 data.frame = DataFrame
@@ -31,6 +32,7 @@ module as
 function matrix end
 
 module data
+global table
 function frame end
 end
 end
@@ -62,7 +64,7 @@ function as.data.frame(x::AbstractMatrix, names)
     DataFrame(x, :auto)
   end
 end
-  
+
 
 as.data.table = as.data.frame
 


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/pull/54678, `Mod.sym = val` is only supposed to work for globals that were previously declared, but the error message for this was accidentally dropped in Julia 1.9 and will likely be put back in Julia 1.11.

As a general note though, you may want to use `const` bindings here rather than `global`s, as the compiler optimizes `const` better.